### PR TITLE
Improve RSS support (with better exposure)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :jekyll_plugins do
     # gem "jekyll-github-metadata", "~> 2.13.0"
     gem 'jekyll-sitemap'
     gem 'jekyll-seo-tag'
-    gem 'jekyll-feed'
+    gem 'jekyll-feed', :git => 'https://github.com/FrederickGeek8/jekyll-feed.git', :branch => 'custom'
     gem 'jekyll-optional-front-matter'
     gem 'jekyll-titles-from-headings'
     gem 'jekyll-relative-links'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -8,10 +8,10 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.0"
+gem 'jekyll', '~> 4.0'
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-#gem "minima", "~> 2.0"
+# gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -19,17 +19,17 @@ gem "jekyll", "~> 4.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-    # gem "jekyll-github-metadata", "~> 2.13.0"
-    gem 'jekyll-sitemap'
-    gem 'jekyll-seo-tag'
-    gem 'jekyll-feed', :git => 'https://github.com/FrederickGeek8/jekyll-feed.git', :branch => 'custom'
-    gem 'jekyll-optional-front-matter'
-    gem 'jekyll-titles-from-headings'
-    gem 'jekyll-relative-links'
-    gem 'jekyll-redirect-from'
+  # gem "jekyll-github-metadata", "~> 2.13.0"
+  gem 'jekyll-feed', git: 'https://github.com/FrederickGeek8/jekyll-feed.git', branch: 'custom'
+  gem 'jekyll-optional-front-matter'
+  gem 'jekyll-redirect-from'
+  gem 'jekyll-relative-links'
+  gem 'jekyll-seo-tag'
+  gem 'jekyll-sitemap'
+  gem 'jekyll-titles-from-headings'
 
-    # from gh-pages
-    gem 'kramdown-parser-gfm'
+  # from gh-pages
+  gem 'kramdown-parser-gfm'
 
-    gem 'comment_generator', path: "_plugins/comment_generator"
+  gem 'comment_generator', path: '_plugins/comment_generator'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/FrederickGeek8/jekyll-feed.git
+  revision: b11f67380a21fa1363d3ba4afd4485cd05ef807f
+  branch: custom
+  specs:
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+
 PATH
   remote: _plugins/comment_generator
   specs:
@@ -54,8 +62,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-feed (0.17.0)
-      jekyll (>= 3.7, < 5.0)
     jekyll-optional-front-matter (0.3.2)
       jekyll (>= 3.0, < 5.0)
     jekyll-redirect-from (0.16.0)
@@ -114,7 +120,7 @@ PLATFORMS
 DEPENDENCIES
   comment_generator!
   jekyll (~> 4.0)
-  jekyll-feed
+  jekyll-feed!
   jekyll-optional-front-matter
   jekyll-redirect-from
   jekyll-relative-links

--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,7 @@ defaults:
 
 feed:
   excerpt_only: true
+  read_more_text: 'Read the full blog post &#x2192;'
   tags: true
   categories:
     - CS

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
 {% endif %}
 <div id="footer" {% if include.tight %}class="tight"{% endif %}>
   <p id="copyright">
-    &copy; {{ site.time | date: '%Y' }} Frederick Morlock. All rights reserved.
+    &copy; 2017-{{ site.time | date: '%Y' }} Frederick Morlock. All rights reserved.
   </p>
 </div>
 </footer>

--- a/_plugins/comment_generator/lib/comment_generator.rb
+++ b/_plugins/comment_generator/lib/comment_generator.rb
@@ -8,6 +8,8 @@ module JekyllComments
     ##
     # Entrpoint to the generator, called by Jekyll
     def generate(site)
+      return unless site.config.key?('comments')
+
       @backend = if site.config['comments']['backend'] == 'sqlite'
                    CommentGenerator::Backends::SqliteBackend.new(site.config['comments']['db_file'])
                  else

--- a/_posts/2023-10-06-thinking-about-grad-school.md
+++ b/_posts/2023-10-06-thinking-about-grad-school.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Thinking About Grad School & Math (Help Wanted)
+title: Thinking About Grad School and Math (Help Wanted)
 date: 2023-10-06 17:15:04 -0400
 last_modified_at: 2024-05-14
 category: Personal

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,9 @@ layout: blog.default
 title: "Posts"
 description: Frederick Morlock's personal blog.
 permalink: '/blog/'
-redirect_from: /blog.html
+redirect_from:
+- /blog.html
+- /blog/posts/
 ---
 
 {% include ext-navigation.html %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -17,6 +17,7 @@ redirect_from: /blog.html
         <div class="spacer">
             <p>My personal blog, where the few posts that escape my drafts folder live. I like to write about
                 mathematics, technology, and some opinions on technology's place in society.</p>
+            <p>You can be notified of new posts by subscribing to my <a href="/feeds/">RSS feed</a>.</p>
         </div>
 
         <h2>{{ page.title }}</h2>

--- a/bookshelf/index.html
+++ b/bookshelf/index.html
@@ -118,12 +118,12 @@ redirect_from: /bookshelf.html
     <ul>
       <li>
         <i>Gödel, Escher, Bach: an Eternal Golden Braid</i> by Douglas Hofstadter
-        <sup>[1]</sup>
+        <sup><a href="#note-1">[1]</a></sup>
       </li>
       <li><i>Remembrance of Earth's Past</i> (Trilogy) by Liu Cixin</li>
       <li>
         <i>Calculus</i>, Fourth Edition by Michael Spivak (ISBN-10 0914098918)
-        <sup>[2]</sup>
+        <sup><a href="#note-2">[2]</a></sup>
       </li>
     </ul>
 
@@ -137,13 +137,13 @@ redirect_from: /bookshelf.html
 </main>
 <hr style="max-width: 250px; margin: 30px auto;" />
 <p>
-  <sup>[1]</sup> This book has truly changed the way I think about intelligence
+  <sup id="note-1">[1]</sup> This book has truly changed the way I think about intelligence
   <i>and</i> formal systems in a profound way. Along with the "Rememeberance of
   Earth's Past" trilogy, this has now become a book that I recommend to many
   people. I think it is highly motivating in some of what I want to focus on in my
   future studies.
   <br/><br/>
-  <sup>[2]</sup> Funnily enough, this is one of my favorite books that I learned
+  <sup id="note-2">[2]</sup> Funnily enough, this is one of my favorite books that I learned
   from during my undergrad. Calculus by Spivak is a great book, even to look
   back on!
 </p>

--- a/feed/index.md
+++ b/feed/index.md
@@ -1,0 +1,31 @@
+---
+layout: blog.basic
+title: "RSS/Atom Feeds"
+permalink: "/feeds/"
+redirect_from: "/feed/"
+---
+
+<h1 id="title">{{ page.title }}</h1>
+
+There are multiple RSS/Atom<sup><a href="#note-1">[1]</a></sup> feeds available on freddy.us, depending on what content you want to subscribe to.
+
+The most important feed is the [**Primary Blog RSS Feed**]({{ "feed.xml" | absolute_url }}) at [**{{ "feed.xml" | absolute_url }}**]({{ "feed.xml" | absolute_url }}).
+
+There are other RSS feeds available if you do not want to subscribe to all posts.
+
+## Per Category Feeds
+If you'd prefer to just subscribe to one category, there are individual feeds for each:
+{% for category in site.categories %}
+- [{{ category[0] }}]({{ "/feed/" | absolute_url | append: category[0] | append: ".xml" }})
+{% endfor %}
+
+## Per Tag Feeds
+Tags are more granual than feeds, and each blog post can have multiple tags (versus just a single category). If you'd prefer a more granual feed than the per-category feeds, you can subscribe to individual tags:
+{% for tag in site.tags %}
+- [{{ tag[0] }}]({{ "/feed/by_tag/" | absolute_url | append: tag[0] | append: ".xml" }})
+{% endfor %}
+
+<hr style="max-width: 250px; margin: 30px auto;" />
+<p>
+    <sup id="note-1">[1]</sup> This website uses <em>Atom</em> feeds rather than RSS feeds, however, most RSS readers also support the Atom feed standard.
+</p>

--- a/feed/index.md
+++ b/feed/index.md
@@ -9,7 +9,7 @@ redirect_from: "/feed/"
 
 There are multiple RSS/Atom<sup><a href="#note-1">[1]</a></sup> feeds available on freddy.us, depending on what content you want to subscribe to.
 
-The most important feed is the [**Primary Blog RSS Feed**]({{ "feed.xml" | absolute_url }}) at [**{{ "feed.xml" | absolute_url }}**]({{ "feed.xml" | absolute_url }}).
+The most important feed is the [**Primary Blog RSS Feed**]({{ "feed.xml" | absolute_url }}) located at [**{{ "feed.xml" | absolute_url }}**]({{ "feed.xml" | absolute_url }}).
 
 There are other RSS feeds available if you do not want to subscribe to all posts.
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: ""
 ## Exploring My Website!
 You can find out more about my personal background, [research interests](/about/#research-interests), and my current tinkering and hobbies over on my [About Me](/about/) page. For more of a focus on my professional background and experiences, you may check out the [Resume/CV](/resume/) tab. Over on "[My Bookshelf](/bookshelf/)" you can find my favorite books, blog posts, and papers that I've read recently.
 
-My "[Blog](/blog/)" is... well... a blog. It supports RSS too! 
+My "[Blog](/blog/)" is... well... a blog. It supports [RSS](/feeds/) too!
 
 If you want to get in touch with me, you can check out my "[Get In Touch!](/contact/)" page. I am always open to having a quick "coffee chat" or collaborating on a project.
 


### PR DESCRIPTION
The main goal of this PR is to improve support for RSS on the blog, as well as improve the way in which it is exposed. 

The primary changes are:
- Adding a "Read the full blog post" link in Atom feed `<summary>`'s leveraging [my fork of `jekyll-feed`](https://github.com/FrederickGeek8/jekyll-feed) (11fe53b45519a648e0603902828430f56b758a0c)
- Changing the title of the blog post "Thinking About Grad School..." due to RSS + Jekyll html encoding limitations (c6069705b0ffb560febfab2c587fb577db58d4b0)
- Created an "RSS hub" for displaying, in a human-readable form, all of the RSS feed links (44075a059ef223b61ecc2249b89b204e76468cc6, cf0ec517d3fa9ef58bb86af96a532e66d930f897)

There were some other unrelated changes, such as setting up redirects, updating copyrights, and styling.